### PR TITLE
Handle incomplete 'data' event from stdout event

### DIFF
--- a/lib/handbrake.js
+++ b/lib/handbrake.js
@@ -51,7 +51,8 @@ HandbrakeProcess.prototype.run = function(options){
     }
 
     var output = "",
-        handle = cp.spawn(_HandbrakeCLIPath, config.toArray());
+        handle = cp.spawn(_HandbrakeCLIPath, config.toArray()),
+        dataBuffer = "";
 
     // propogate CTRL+C to Handbrake process
     var sigInt = function(){
@@ -64,8 +65,11 @@ HandbrakeProcess.prototype.run = function(options){
 
     handle.stdout.on("data", function(data){
         output += data;
-        if (/Encoding:/.test(data)){
-            var match = data.match(/task (\d) of (\d), ((.+?), )?(.*) %( \((.*?) fps, avg (.*?) fps, ETA (.*?)\))?/);
+        dataBuffer += data;
+
+        if (/\rEncoding:[^\r]*\r/.test(dataBuffer)) { //ensure complete line available in buffer from \r -to- \r
+            var bufferMatch = dataBuffer.match(/\r[^\r]*\r/)[0];
+            var match = bufferMatch.match(/task (\d) of (\d), ((.+?), )?(.*) %( \((.*?) fps, avg (.*?) fps, ETA (.*?)\))?/);
             var progress = {
                 taskNumber: match[1],
                 taskCount: match[2],
@@ -75,6 +79,7 @@ HandbrakeProcess.prototype.run = function(options){
                 eta: match[9] || 0,
                 task: match[4] || "Encoding"
             };
+            dataBuffer = dataBuffer.replace(/\r[^\r]*\r/,"\r") //Remove used data from buffer
 
             /**
             Fired at regular intervals passing progress information


### PR DESCRIPTION
Noticed during testing in Windows 7 that the `stdout.data` Event would not always pass a complete line of `processing` data but instead an incomplete line of data, causing an exception.
#### Expecting:

`Encoding: task <var> of <var> ...etc`
#### Occasionally (Windows 7)

`Encoding: task`

This would pass the initial test [handbrake.js:67](https://github.com/75lb/handbrake-js/blob/be78de8b4ec7a6f5dcb8850ade6fdd4fe9c09a12/lib/handbrake.js#L67) but would throw an exception when trying to access `match[1]`.

With this PR I propose that we instead always expect an incomplete line and use a buffer. Test this buffer with `/rEncoding:/r` and after useage, pop that line from the buffer.
