### PR TITLE
Catch error events emitted cp.spawn, and re-emit an error.

### DIFF
--- a/lib/handbrake.js
+++ b/lib/handbrake.js
@@ -140,6 +140,16 @@ HandbrakeProcess.prototype.run = function(options){
     handle.on("exit", function(){
         process.removeListener("SIGINT", sigInt);
     });
+    handle.on('error', function (err){
+        process.removeListener("SIGINT", sigInt);
+        if (err.code === 'ENOENT'){
+            self.emit('error', new Error('handbrakejs spawn error: ' + _HandbrakeCLIPath + ' is not installed.'));
+        }
+        else{
+            self.emit('error', new Error('handbrakejs spawn error: ' + err));
+        }
+    });
+
 };
 
 /**


### PR DESCRIPTION
Unless this exception is caught, nodejs will halt with without a clear error message.
