### PR TITLE
Fix invalid HandBreakCLI file name

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -17,7 +17,7 @@ const version = '1.2.2'
 const downloadPath = 'https://github.com/HandBrake/HandBrake/releases/download/%s/HandBrakeCLI-%s%s'
 
 const win32 = {
-  url: util.format(downloadPath, version, version, '-win-i686.zip'),
+  url: util.format(downloadPath, version, version, '-win-x86_64.zip'),
   archive: 'win.zip',
   copyFrom: path.join('unzipped', 'HandBrakeCLI.exe'),
   copyTo: path.join('bin', 'HandbrakeCLI.exe')


### PR DESCRIPTION
```
λ yarn global add handbrake-js
yarn global v1.19.1
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
[1/2] ⠁ now
error C:\Users\marcel\AppData\Local\Yarn\Data\global\node_modules\handbrake-js: Command failed.
Exit code: 1
Command: node scripts/install.js
Arguments:
Directory: C:\Users\marcel\AppData\Local\Yarn\Data\global\node_modules\handbrake-js
Output:
fetching: https://github.com/HandBrake/HandBrake/releases/download/1.2.2/HandBrakeCLI-1.2.2-win-i686.zip
extracting: unzipped\HandBrakeCLI.exe
events.js:174
      throw er; // Unhandled 'error' event
      ^

Error: ENOENT: no such file or directory, open 'C:\Users\marcel\AppData\Local\Yarn\Data\global\node_modules\handbrake-js\unzipped\HandBrakeCLI.exe'
Emitted 'error' event at:
    at lazyFs.open (internal/fs/streams.js:115:12)
    at FSReqWrap.args [as oncomplete] (fs.js:140:20)
```
Probably unintentional issue due to the most recent change [here](https://github.com/75lb/handbrake-js/commit/8587e81bcf407d75e56935d0a171b0612f68643b).
> https://github.com/HandBrake/HandBrake/releases/download/1.2.2/HandBrakeCLI-1.2.2-win-i686.zip

doesn't exist in their GitHub releases.