### PR TITLE
HandbrakeCLI throwing errors when unknown arg added

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,7 @@ Encoding  1.07       131.76    158.12    00h21m11s
 Handbrake for node.js.
 
 **Example**  
-```js
-const hbjs = require('handbrake-js')
-```
+```jsconst hbjs = require('handbrake-js')```
 
 * [handbrake-js](#module_handbrake-js)
     * _static_
@@ -116,19 +114,7 @@ Spawns a HandbrakeCLI process with the supplied [options](https://handbrake.fr/d
 | [options.HandbrakeCLIPath] | <code>string</code> | Override the built-in `HandbrakeCLI` binary path. |
 
 **Example**  
-```js
-const hbjs = require('handbrake-js')
-
-const options = {
-  input: 'something.avi',
-  output: 'something.mp4',
-  preset: 'Normal',
-  rotate: 1
-}
-hbjs.spawn(options)
-  .on('error', console.error)
-  .on('output', console.log)
-```
+```jsconst hbjs = require('handbrake-js')const options = {  input: 'something.avi',  output: 'something.mp4',  preset: 'Normal',  rotate: 1}hbjs.spawn(options)  .on('error', console.error)  .on('output', console.log)```
 <a name="module_handbrake-js.exec"></a>
 
 ### hbjs.exec(options, [onComplete])
@@ -143,14 +129,7 @@ Runs HandbrakeCLI with the supplied [options](https://handbrake.fr/docs/en/lates
 | [onComplete] | <code>function</code> | If passed, `onComplete(err, stdout, stderr)` will be called on completion, `stdout` and `stderr` being strings containing the HandbrakeCLI output. |
 
 **Example**  
-```js
-const hbjs = require('handbrake-js')
-
-hbjs.exec({ preset-list: true }, function(err, stdout, stderr){
-  if (err) throw err
-  console.log(stdout)
-})
-```
+```jsconst hbjs = require('handbrake-js')hbjs.exec({ preset-list: true }, function(err, stdout, stderr){  if (err) throw err  console.log(stdout)})```
 <a name="module_handbrake-js.run"></a>
 
 ### hbjs.run(options) ⇒ <code>Promise</code>
@@ -164,17 +143,7 @@ Identical to `hbjs.exec` except it returns a promise, rather than invoke a callb
 | [options.HandbrakeCLIPath] | <code>string</code> | Override the built-in `HandbrakeCLI` binary path. |
 
 **Example**  
-```js
-const hbjs = require('handbrake-js')
-
-async function start () {
-  const result = await hbjs.run({ version: true })
-  console.log(result.stdout)
-  // prints 'HandBrake 1.3.0'
-}
-
-start().catch(console.error)
-```
+```jsconst hbjs = require('handbrake-js')async function start () {  const result = await hbjs.run({ version: true })  console.log(result.stdout)  // prints 'HandBrake 1.3.0'}start().catch(console.error)```
 <a name="module_handbrake-js..Handbrake"></a>
 
 ### handbrake-js~Handbrake ⇐ [<code>EventEmitter</code>](http://nodejs.org/api/events.html)

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -216,8 +216,12 @@ class Handbrake extends events.EventEmitter {
         return
       }
     }
+    
+    /* Ensure the CLI Path is not included into the spawn args when parsed from the options */
+    const spawnOptions = {...this.options};
+    delete spawnOptions.HandbrakeCLIPath;
 
-    const spawnArgs = objectToSpawnArgs(this.options, {
+    const spawnArgs = objectToSpawnArgs(spawnOptions, {
       optionEqualsValue: true,
       optionEqualsValueExclusions: ['preset-import-file', 'preset-import-gui', 'subtitle-burned']
     });
@@ -627,10 +631,14 @@ function spawn (options = {}, mocks) {
  * @alias module:handbrake-js.exec
  */
 function exec (options = {}, done) {
+  /* Ensure the CLI Path is not included into the spawn args when parsed from the options */
+  const spawnOptions = {...options};
+  delete spawnOptions.HandbrakeCLIPath;
+
   const cmd = util__default['default'].format(
     '"%s" %s',
     options.HandbrakeCLIPath || HandbrakeCLIPath,
-    objectToSpawnArgs(options, { quote: true }).join(' ')
+    objectToSpawnArgs(spawnOptions, { quote: true }).join(' ')
   );
   childProcess__default['default'].exec(cmd, done);
 }

--- a/index.js
+++ b/index.js
@@ -74,10 +74,14 @@ function spawn (options = {}, mocks) {
  * @alias module:handbrake-js.exec
  */
 function exec (options = {}, done) {
+  /* Ensure the CLI Path is not included into the spawn args when parsed from the options */
+  const spawnOptions = {...options}
+  delete spawnOptions.HandbrakeCLIPath;
+
   const cmd = util.format(
     '"%s" %s',
     options.HandbrakeCLIPath || HandbrakeCLIPath,
-    toSpawnArgs(options, { quote: true }).join(' ')
+    toSpawnArgs(spawnOptions, { quote: true }).join(' ')
   )
   cp.exec(cmd, done)
 }

--- a/lib/Handbrake.js
+++ b/lib/Handbrake.js
@@ -71,8 +71,12 @@ class Handbrake extends EventEmitter {
         return
       }
     }
+    
+    /* Ensure the CLI Path is not included into the spawn args when parsed from the options */
+    const spawnOptions = {...this.options}
+    delete spawnOptions.HandbrakeCLIPath;
 
-    const spawnArgs = toSpawnArgs(this.options, {
+    const spawnArgs = toSpawnArgs(spawnOptions, {
       optionEqualsValue: true,
       optionEqualsValueExclusions: ['preset-import-file', 'preset-import-gui', 'subtitle-burned']
     })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "handbrake-js",
   "author": "Lloyd Brookes <75pound@gmail.com>",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Handbrake for node.js. Brings video encoding.",
   "repository": "https://github.com/75lb/handbrake-js",
   "license": "MIT",

--- a/test/exec.js
+++ b/test/exec.js
@@ -21,7 +21,7 @@ tom.test('HandbrakeCLIPath', async function () {
   return new Promise((resolve, reject) => {
     hbjs.exec({ 'preset-list': true, HandbrakeCLIPath: 'one' }, function (err, stdout, stderr) {
       if (err) {
-        a.equal(err.cmd, '"one" --preset-list --HandbrakeCLIPath "one"')
+        a.equal(err.cmd, '"one" --preset-list')
         resolve()
       } else {
         reject(new Error("Shouldn't reach here"))

--- a/test/spawn-exception-handling.js
+++ b/test/spawn-exception-handling.js
@@ -15,7 +15,7 @@ tom.test('validation: HandbrakeCLI not found', function () {
         a.equal(err.name, 'HandbrakeCLINotFound')
         a.ok(/HandbrakeCLI application not found/.test(err.message))
         a.equal(err.HandbrakeCLIPath, 'broken/path')
-        a.ok(err.errno === 'ENOENT' || err.errno === -2)
+        a.ok(err.errno === 'ENOENT' || err.errno === -2 || err.errno === -4058)
         a.ok(/ENOENT/.test(err.spawnmessage))
         a.deepEqual(err.options, { input: 'in', output: 'out', HandbrakeCLIPath: 'broken/path' })
         resolve()


### PR DESCRIPTION
Fixes an issue I had when defining the `HandbrakeCLIPath` as an option, it would attempt to add it as a spawn argument and caused Handbrake to error and die.

Fix, simply remove `HandbrakeCLIPath` from the options getting sent to the `objectToSpawnArgs` function


Not sure why the readme registers as all those changes...
